### PR TITLE
Update imagesloaded to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "flickity-imagesloaded.js",
   "dependencies": {
     "flickity": "^2.0.0",
-    "imagesloaded": "^4.1.0"
+    "imagesloaded": "^5.0.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Without this change, Flickity can't be used with srcset which is loading multiple images in v4. Based on the documentation that should be solved with v5 of imagesloaded.